### PR TITLE
feat: add api secret global validation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,8 @@ import { UserModule } from './user/user.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import databaseConfig from './db/database.config';
+import { InternalApiGuard } from './guards/internal-api.guard';
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -17,6 +19,12 @@ import databaseConfig from './db/database.config';
       inject: [ConfigService],
     }),
     UserModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: InternalApiGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/src/guards/internal-api.guard.ts
+++ b/src/guards/internal-api.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class InternalApiGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const { headers } = request;
+
+    return headers['x-api-secret'] === this.configService.get('API_SECRET');
+  }
+}


### PR DESCRIPTION
**Contexto**
Para requisições internas, precisamos de segurança, para que saibamos que o cliente que está fazendo a requisição realmente tem a permissão para fazê-la. 

**Objetivo**
Para isso, foi criado um header com um segredo: `X-API-SECRET` que é validado no serviço por meio de um guard.

**Changelog**
[feat: add api secret global validation](https://github.com/qfila/qfila-users-service/commit/452a1e0412031e89c3b031b4a757d5f753c33f68)

**Evidências visuais**
N/A

**Checklist antes de abrir o PR**

- [ ] Existe alguma breaking change sendo intrudoduzida?
- [x] Funcionalidade foi testada manualmente?
- [x] Reviewers adicionados?
- [x] Tags adicionadas?
